### PR TITLE
A few corrections

### DIFF
--- a/vignettes/recordSwapping.Rmd
+++ b/vignettes/recordSwapping.Rmd
@@ -20,14 +20,14 @@ library(recordSwapping)
 
 ## Overview
 
-This is the vignette for the R-Package *recordSwapping* which can be used to apply the record swapping algorithm to a micro data set.
+This is the vignette for the R-Package *recordSwapping*, which can be used to apply the record swapping algorithm to a micro data set.
 The implementation of the procedure was done purely in C++ and is based on the SAS code on targeted record swapping from ONS (https://ec.europa.eu/eurostat/cros/content/2-record-swapping_en). 
-There are however substantial differences between the SAS- and C++-Code. Some of these differences are the result of improving the run-time for the C++ implementation. In the next section the differences between the 2 implementations are presented further.
-. The R-Package is just as a front end to easily call the procedures und for testing purposes.
+There are, however, substantial differences between the SAS and C++ Code. Some of these differences are the result of improving the run-time for the C++ implementation. In the next section, the differences between the 2 implementations are presented further.
+The R-Package is just as a front end to easily call the procedures and for testing purposes.
 
 
 ## Functionality
-The targeted record swapping can be applied with the function `recordSwap()`. All other functions in the package are called from inside `recordSwap()` and are only exportet for testing purposes. The function has the following arguments:
+The targeted record swapping can be applied with the function `recordSwap()`. All other functions in the package are called from inside `recordSwap()` and are only exported for testing purposes. The function has the following arguments:
 
 ```{Rcpp,include=TRUE,eval=FALSE}
 recordSwap(std::vector< std::vector<int> > data, int hid,
@@ -45,17 +45,17 @@ recordSwap(std::vector< std::vector<int> > data, int hid,
 
 + **data** micro data containing ONLY integer values, rectangular table format.
 + **hid** column index in \code{data} which refers to the household identifier.
-+ **hierarchy** column indices of variables in \code{data} which refere to the geographic hierarchy in the micro data set. For instance county > municipality > district.
-+ **similar** vector of vector containing the similarity profiles that is sets of variables in \code{data} which should be considered when swapping households. \code{similar[0]} corresponds to the first set similarity variables, \code{similar[1]} to the second set and so on. 
++ **hierarchy** column indices of variables in \code{data} which refer to the geographic hierarchy in the micro data set. For instance county > municipality > district.
++ **similar** vector of vector containing the similarity profiles that are sets of variables in \code{data} which should be considered when swapping households. \code{similar[0]} corresponds to the first set similarity variables, \code{similar[1]} to the second set and so on. 
 + **swaprate** double between 0 and 1 defining the proportion of households which should be swapped, see details for more explanations
-+ **risk** vector of vector containing the risk of each individual for each hierarchy level. `risk[0]` corresponds to the risks of the first record for all hierachy levels, `risk[1]` for the second record and so on. Should be ignored for now, is not fully tested yet.
-+ **risk_threshold** risk threshold which determines if a record has to be swapped and over which hierarchy level. This overwrites k_anonymity.
-Should be ignored for now, is not fully tested yet.
-+ **k_anonymity** integer defining the threshhold of high risk households (k-anonymity). A record is not at risk if `k_anonymity > counts`.
++ **risk** vector of vector containing the risk of each individual for each hierarchy level. `risk[0]` corresponds to the risks of the first record for all hierarchy levels, `risk[1]` for the second record and so on. Should be ignored, for now, it is not fully tested yet.
++ **risk_threshold** risk threshold, which determines if a record has to be swapped and over which hierarchy level. This overwrites k_anonymity.
+Should be ignored, for now, it is not fully tested yet.
++ **k_anonymity** integer defining the threshold of high risk households (k-anonymity). A record is not at risk if `k_anonymity > counts`.
 + **risk_variables** column indices of variables in \code{data} which will be considered for estimating the risk. This is only used if `risk` was not supplied.
 + **carry_along** column indices of variables in \code{data} which are additionally swapped. These variables do not interfere with the procedure of finding a record to swap with. This parameter is only used at the end of the procedure when swapping the hierarchies.
 + **count_swapped_records**, **count_swapped_hid** count number of households and records swapped
-+ **log_file_name** path for writing a log file. The log file contains a list of household IDs (`hid`) which could not have been swapped and is only created if any such households exist.
++ **log_file_name** path for writing a log file. The log file contains a list of household IDs (`hid`) that could not have been swapped and is only created if any such households exist.
 + **seed** integer defining the seed for the random number generator, for reproducibility.
 
 **IMPORTANT**: The argument `data` contains the micro data and can be understood as a vector of vectors. Inside the function, `data` is expected to contain each column of the input data as `std::vector<int>` which are then again stored in an `std::vector< std::vector<int> >`. So `data[0]` addresses variables of the first record and `data[0][0]` the first column of the first record. The same logic hold for the argument `risk`.
@@ -63,14 +63,14 @@ Should be ignored for now, is not fully tested yet.
 
 ### Some differences to SAS-Code
 
-#### Riskdefinition
+#### Risk definition
 
 + **C++-Code**: Risk is calculated using counts over the geographic hierarchies (`hierarchy`) and the combination of all risk variables.
-+ **SAS-Code**: Risk is calculated using counts for each geographic hierarchy (`hierarchy`) and risk variable seperately. These risks are then combined to produce a single risk value for each record.
++ **SAS-Code**: Risk is calculated using counts for each geographic hierarchy (`hierarchy`) and risk variable separately. These risks are then combined to produce a single risk value for each record.
 
 #### Sampling probability
 
-+ **C++-Code**: Sampling probability $p_{y,h}$ for household $y$ at the geographic hierarhcy $h$ is derived from the risks $r_{i,h}$ of all individuals living in the same household. 
++ **C++-Code**: Sampling probability $p_{y,h}$ for household $y$ at the geographic hierarchy $h$ is derived from the risks $r_{i,h}$ of all individuals living in the same household. 
 The risk $r_{i,h}$ for each individual $i$ in geographic hierarchy ($h$) is currently estimated through the k-anonymity rule. $r_{i,h}$ is then defined as 
 
 $$
@@ -85,14 +85,14 @@ $$
 r_{i,h} \sim \frac{1}{counts} \quad .
 $$
 
-The sampling probabiliy for household household $y$, $p_{y,h}$ in hierarchy $h$, is then defined by the maximum of risk across all household member
+The sampling probability for household $y$, $p_{y,h}$ in hierarchy $h$, is then defined by the maximum of risk across all household member
 
 $$
 p_{y,h} = \max_{i\text{ in household }y}(r_{i,h}) \quad .
 $$
 This sampling probability is used for selecting households for swapping as well as donor households. 
 
-+ **SAS-Code**: Sampling probability is derived from the multiple factors.
++ **SAS-Code**: Sampling probability is derived from multiple factors.
     
 $$
 p_i = \begin{cases}
@@ -112,12 +112,12 @@ with $SA$ as the sample size, $N_{high}$ as the number of high risk households i
 
 #### Swapping Records
 
-+ **C++-Code**: Swaps are made in every hierarchy level and records wich do not fullfill the k-anonymity are swapped. The donor set of records to be swapped with is always made out of every record wich does not belong to the same geographic area as the swapped households. At the lowest hierarchy level an additional number of households is swapped such that the proportion of households swapped is equal the number in `swaprate`. If the proportion of already swapped households succeeds this values then records wich do not fullfill the k-anonymity are also swapped.
++ **C++-Code**: Swaps are made in every hierarchy level and records which do not fulfil the k-anonymity are swapped. The donor set of records to be swapped with is always made out of every record which does not belong to the same geographic area as the swapped households. At the lowest hierarchy level, an additional number of households is swapped such that the proportion of households swapped is equal to the number in `swaprate`. If the proportion of already swapped households succeeds these values then records that do not fulfil the k-anonymity are also swapped.
 
 
-![Example for swapping households. The number represent the number of high risk households at each hierachy level.](diagram.png){width=100%}
+![Example for swapping households. The number represents the number of high risk households at each hierarchy level.](diagram.png){width=100%}
 
-Figure 1 displays an example with hierarchy levels NUTS1 > NUTS2 > NUTTS3 where the number of high risk households are displayed at the end of the edges. For instance in the first NUTS1 region there are 5 high risk households which will be swapped with households from other NUTS1 regions. In the first NUTS2 region there are 10 high risk households which will be swapped with households which are not in the same NUTS2 region. At the lowest level, the NUTS3 regions, the number of swaps, $n_{swaps}$ for the first district is defined by
+Figure 1 displays an example with hierarchy levels NUTS1 > NUTS2 > NUTTS3 where the numbers of high risk households are displayed at the end of the edges. For instance, in the first NUTS1 region, there are 5 high risk households that will be swapped with households from other NUTS1 regions. In the first NUTS2 region, there are 10 high risk households that will be swapped with households that are not in the same NUTS2 region. At the lowest level, the NUTS3 regions, the number of swaps, $n_{swaps}$ for the first district is defined by
 
 $$
 n_{swaps} = 2 + Rest\\
@@ -125,8 +125,8 @@ Rest = \max(0,N\cdot s - n_{already})
 $$
 with $N$ as the number of households in the district, $n_{already}$ as the number of already swapped households in the district and $s$ as the swap rate. 
 
-+ **SAS-Code** Swaps are made in every hierarchy level and depending on the sampling probability high risk households are more likely to be swapped than low risk households, but they are not mandatorilly swapped. The number of swappes in each hierachy level is defined by the number of high risk records and total number records in the geographic area.
-For instance having the geographic hierarchy county > municipality > district, the number of Swaps in the municipality $m$ of county $n$ is defined by
++ **SAS-Code** Swaps are made in every hierarchy level and depending on the sampling probability, high risk households are more likely to be swapped than low risk households, but they are not mandatorily swapped. The number of swappes in each hierarchy level is defined by the number of high risk records and the total number of records in the geographic area.
+For instance, having the geographic hierarchy county > municipality > district, the number of Swaps in the municipality $m$ of county $n$ is defined by
 
 $$
 SWAP_m = \frac{SIZE_m+RISK_m}{2}
@@ -137,7 +137,7 @@ $$
 SIZE_m = \frac{N_m^{-1}}{\sum_iN_i^{-1}}\cdot sN_n
 $$
 with $N_m$ as the number of households in municipality $m$, $s$ the global swaprate and $N_n$ as the number of households in county $n$.
-$RISK_m$ can be derived using the proportion of of high risk households in each municipality
+$RISK_m$ can be derived using the proportion of high risk households in each municipality
 
 $$
 RISK_m = \frac{H_m}{\sum_iH_i}\cdot sN_n
@@ -147,7 +147,7 @@ with $H_m$ as the proportion of high risk households in municipality $m$.
 
 ## Application
 
-The package was tested on randomly generated data, which contained 5 geographic levels and some other soziodemographic variables.
+The package was tested on randomly generated data, which contained 5 geographic levels and some other sociodemographic variables.
 ```{r}
 library(recordSwapping)
 dat <- createDat(N=100000)
@@ -182,7 +182,7 @@ Here the procedure was applied to `dat`
 + setting the k-anonymity rule to 3
 + setting the swaprate to 0.05
 
-If `k_anonymity <- 0` only the swaprate is considered. Then at most `th*100`% of the households are swapped. If the sample is very small the actual number of swaps can be smaller, however this can only happen if some regions have a very small number of households e.g. 1,2,3,...
+If `k_anonymity <- 0` only the swaprate is considered. Then at most `th*100`% of the households are swapped. If the sample is very small, the actual number of swaps can be smaller, however, this can only happen if some regions have a very small number of households, e.g. 1,2,3,...
 
 ```{r}
 k_anonymity <- 0
@@ -212,7 +212,7 @@ dat[,uniqueN(hid)]*swaprate
 
 ### Supplying index vectors
 
-Instead of column names index vectors can be supplied for parameters `hid`, `hierarchy`, `similar` and `risk_variables`.
+Instead of column names, index vectors can be supplied for parameters `hid`, `hierarchy`, `similar` and `risk_variables`.
 
 ```{r}
 hierarchy <- c(1,2) # ~ c("nuts1","nuts2")
@@ -235,8 +235,8 @@ So using column indices for this function call should be done in the usually `R`
 
 ### Similarity profiles
 
-In some cases the condition of finding a *similar* household given by the parameter `similarity` might be too strict.
-And thus it is not possible to swap the necessary number of households due too lack of a siutable donor household.
+In some cases, the condition of finding a *similar* household given by the parameter `similarity` might be too strict.
+And thus, it is not possible to swap the necessary number of households due to the lack of a suitable donor household.
 
 ```{r}
 # demonstrate on small data set
@@ -258,7 +258,7 @@ dat_swapped <- recordSwap(data = dat, hid = hid,
 ```
 
 The expected number of swapped households for a population of `r dat[,uniqueN(hid)]` households and a swapping rate of `r swaprate` is `r dat[,uniqueN(hid)]*swaprate`.
-The acutal number of swaps was however:
+The actual number of swaps was however:
 ```{r}
 dat_compare <- merge(dat[,.(paste(nuts1[1],nuts2[1])),by=hid],
                      dat_swapped[,.(paste(nuts1[1],nuts2[1])),by=hid],by="hid")
@@ -297,9 +297,9 @@ nrow(dat_compare[V1.x!=V1.y])
 ### Carry along variables
 
 Using the function `recordSwap()` like above always results in swapping the variables defined through variable `hierarchy`.
-Sometimes it might be useful to swap more variables then the ones stated in hierarchy.
+Sometimes it might be useful to swap more variables than the ones stated in hierarchy.
 
-When we apply the record swapping using `hierarchy`-levels `nuts1` and `nuts2` then the `nuts3` and `lau2`-variable in our data set will stay unchanged. Thus for the resulting data set the variables `nuts1` and `nuts2` are no longer coherent with `nuts3` and `lau2`.
+When we apply the record swapping using `hierarchy`-levels `nuts1` and `nuts2` then the `nuts3` and `lau2`-variable in our data set will stay unchanged. Thus for the resulting data set, the variables `nuts1` and `nuts2` are no longer coherent with `nuts3` and `lau2`.
 
 Let's have a more detailed look at the problem
 
@@ -356,7 +356,7 @@ all.equal(dat_geo,dat_geo_swapped)
 ```
 
 Both the original and swapped data set have the same value combinations for `nuts1`, `nuts2` and `nuts3`.
-Setting this parameter did however not interfere with the swapping procedure
+Setting this parameter did, however, not interfere with the swapping procedure
 
 ```{r}
 dat_compare2 <- merge(dat[,.(paste(nuts1[1],nuts2[1])),by=hid],
@@ -382,7 +382,7 @@ dat_swapped3 <- recordSwap(data = copy(dat),
                         seed=1234L)
 ```
 
-The output now has an additional column named `hid_swapped` which contains the household ID with which a household was swapped with.
+The output now has an additional column named `hid_swapped`, which contains the household ID with which a household was swapped with.
 
 Number of swapped `hid`s
 ```{r}
@@ -392,8 +392,8 @@ dat_swapped3[!duplicated(hid),.N,by=.(id_swapped = hid!=hid_swapped)]
 ### Information loss
 
 With the function `infoLoss()` one can calculate various information loss measures over a pre defined frequency table.
-This frequency table is defined by the paramter `table_vars` which accepts column names of the original and swapped micro data.
-The frequency table is internally constructed using both the original and swapped micro data. Afterwards various information loss measures are estimated over each of the table cells. 
+This frequency table is defined by the parameter `table_vars`, which accepts column names of the original and swapped micro data.
+The frequency table is internally constructed using both the original and swapped micro data. Afterwards, various information loss measures are estimated over each of the table cells. 
 
 ```{r}
 # calculate information loss for frequecy table nuts2 x national
@@ -417,7 +417,7 @@ $$
 abs\_sqr(x,y) = |\sqrt{x}-\sqrt{y}|
 $$
 
-It is also possible to supply a custom information loss metric by using paramter `custom_meric`
+It is also possible to supply a custom information loss metric by using parameter `custom_meric`
 
 ```{r}
 # define squared distance as custom metric
@@ -430,5 +430,4 @@ iloss <- infoLoss(data=dat, data_swapped = dat_swapped3,
                   custom_metric = list(squareD=squareD))
 iloss$measures # includes custom loss as well
 ```
-
 


### PR DESCRIPTION
Hello, I came across a few typos while reading your nicely described vignette.
So I fixed them. Would you accept my little contribution?
It was a few commas and the following corrections:
line 30 und => and
line 30 exportet => exported
line 48 refere => refer
line 49 is => are
line 51 hierachy => hierarchy
line 54 threshhold => threshold 
line 58 which could => that could
line 66 Riskdefinition => Risk definition
line 69 seperately => separately 
line 73 hierarhcy => hierarchy
line 88 probabiliy => probability 
line 88 household household => household 
line 115 wich => which 
line 115 fullfill => fulfil 
line 115 wich => which 
line 115 equal the number => equal to the number
line 115 this values => these values
line 115 wich => which => that
line 115 fullfill => fulfil 
line 118 represent => represents
line 118 hierachy => hierarchy
line 120 number => numbers
line 120 which will => that will
line 120 which are => that are
line 128 mandatorilly => mandatorily 
line 128 hierachy => hierarchy
line 128 number records => number of records
line 140 of of => of
line 150 soziodemographic => sociodemographic 
line 239 too => to
line 239 siutable => suitable 
line 261 acutal => actual 
line 300 then => than 
line 395 paramter => parameter 
line 420 paramter => parameter